### PR TITLE
Link to docs from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ defmodule MyModule do
 end
 ```
 
+For more details see the [documentation](https://hexdocs.pm/multiverses)
+
 ## Testing
 
 you can activate multiple copies of all the tests by passing the


### PR DESCRIPTION
Currently when reading the Readme a person might assume that there isn't very much documentation for the library but there's actually some more documentation in the docs.