### PR TITLE
Return nil from id/2 with strict: false and no shard

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -84,3 +84,8 @@
 ## 0.11.0
 
 - mostly documentation changes.  Likely to be last version before 1.0
+
+## 0.11.1
+
+- `Multiverses.id/2` with `strict: false` now returns `nil` for an
+  unsharded process instead of crashing

--- a/lib/multiverses/server.ex
+++ b/lib/multiverses/server.ex
@@ -84,15 +84,19 @@ defmodule Multiverses.Server do
   end
 
   def id(module, options) do
-    pair = id_pair(module)
     strict = Keyword.get(options, :strict, true)
 
-    unless not strict or pair do
-      raise UnexpectedCallError,
-            "no shard defined for module #{inspect(module)} in #{format_process()}"
-    end
+    case id_pair(module) do
+      {_pid, id} ->
+        id
 
-    elem(pair, 1)
+      nil when strict ->
+        raise UnexpectedCallError,
+              "no shard defined for module #{inspect(module)} in #{format_process()}"
+
+      nil ->
+        nil
+    end
   end
 
   defp id_pair(module) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Multiverses.MixProject do
   use Mix.Project
 
-  def version, do: "0.11.0"
+  def version, do: "0.11.1"
 
   def project do
     [

--- a/test/multiverses_test.exs
+++ b/test/multiverses_test.exs
@@ -11,6 +11,10 @@ defmoduler MultiversesTest do
         Multiverses.id(Application)
       end
     end
+
+    test "obtaining the id with strict: false returns nil instead of crashing" do
+      assert Multiverses.id(Application, strict: false) == nil
+    end
   end
 
   describe "when you try to register the same shard more than once" do


### PR DESCRIPTION
Fixes #9.

## Problem

`Multiverses.id(module, strict: false)` is documented to return `nil` when the current process has no shard, but it crashed instead:

```
** (ArgumentError) errors were found at the given arguments:
   * 2nd argument: not a tuple
    :erlang.element(2, nil)
    lib/multiverses/server.ex:95: Multiverses.Server.id/2
```

When `pair == nil` and `strict: false`, the `unless` guard correctly skipped the raise, but execution fell through to `elem(pair, 1)` = `elem(nil, 1)`.

This bites `multiverses_pubsub` with `strict: false`: any `subscribe`/`broadcast` from an unsharded process (a sync test, or an app-supervised process) crashes instead of falling back to the unsharded topic — the whole point of `strict: false`.

## Fix

Rewrite `id/2` as a `case` over `id_pair/1` — the same shape already used in `shard_impl/4`:

- `{_pid, id}` → return the id
- `nil` + strict → raise `UnexpectedCallError`
- `nil` + not strict → return `nil`

## Test

Adds a case under "when you haven't sharded into a multiverse" asserting `Multiverses.id(Application, strict: false) == nil`. Full suite: 48 tests, 0 failures.